### PR TITLE
refactor(auth): rename logout functionality to clearAuth and update related services

### DIFF
--- a/Project 4 network/network-frontend/src/contexts/AuthContext.tsx
+++ b/Project 4 network/network-frontend/src/contexts/AuthContext.tsx
@@ -21,7 +21,7 @@ interface AuthContextType {
   user: User | null;
   setUser: (user: User | null) => void;
   isAuthenticated: boolean;
-  logout: () => void;
+  clearAuth: () => void;
   loading?: boolean;
   _isDefault?: boolean;
 }
@@ -31,7 +31,7 @@ const defaultContextValue: AuthContextType = {
   user: null,
   setUser: () => {},
   isAuthenticated: false,
-  logout: () => {},
+  clearAuth: () => {},
 };
 
 const AuthContext = createContext<AuthContextType>({
@@ -61,7 +61,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const isAuthenticated = user !== null;
-  const logout = () => {
+  const clearAuth = () => {
     setUser(null);
     localStorage.removeItem("user");
   };
@@ -73,7 +73,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         setUser,
         isAuthenticated,
-        logout,
+        clearAuth,
         _isDefault: false, // Value provided by Provider is not default
       }}
     >

--- a/Project 4 network/network-frontend/src/layouts/MainLayout.tsx
+++ b/Project 4 network/network-frontend/src/layouts/MainLayout.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { logoutUser } from "../services/authService";
+import { logoutApi } from "../services/authService";
 import { useAuth } from "../contexts/AuthContext";
 
 export default function MainLayout({
@@ -9,7 +9,7 @@ export default function MainLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { user, logout } = useAuth();
+  const { user, clearAuth } = useAuth();
   const [error, setError] = useState("");
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
@@ -20,8 +20,8 @@ export default function MainLayout({
     setIsLoading(true);
 
     try {
-      await logoutUser(); // Backend logout API
-      logout(); // Frontend logout
+      await logoutApi(); // Backend logout API
+      clearAuth(); // Frontend logout
       navigate("/login");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Logout failed");

--- a/Project 4 network/network-frontend/src/services/authService.ts
+++ b/Project 4 network/network-frontend/src/services/authService.ts
@@ -19,7 +19,7 @@ export const loginUser = async (username: string, password: string) => {
   return data as LoginResponse;
 };
 
-export const logoutUser = async () => {
+export const logoutApi = async () => {
   return fetchWithConfig("/logout", {
     method: "POST",
   });

--- a/Project 4 network/network-frontend/tests/MainLayout.test.tsx
+++ b/Project 4 network/network-frontend/tests/MainLayout.test.tsx
@@ -5,14 +5,14 @@ import MainLayout from "../src/layouts/MainLayout";
 import { AuthProvider } from "../src/contexts/AuthContext";
 import * as authService from "../src/services/authService";
 import React from "react";
-import { logoutUser } from "../src/services/authService";
+import { logoutApi } from "../src/services/authService";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 // Mock the authService
 vi.mock("../src/services/authService", () => ({
   checkAuthStatus: vi.fn(),
-  logoutUser: vi.fn(),
+  logoutApi: vi.fn(),
 }));
 
 const renderMainLayout = () => {
@@ -99,7 +99,7 @@ describe("MainLayout", () => {
       const logoutPromise = new Promise((resolve) => {
         resolveLogout = resolve;
       });
-      vi.mocked(logoutUser).mockImplementation(() => logoutPromise);
+      vi.mocked(logoutApi).mockImplementation(() => logoutPromise);
 
       renderMainLayout();
 
@@ -128,7 +128,7 @@ describe("MainLayout", () => {
 
     it("displays error message on logout failure", async () => {
       const user = userEvent.setup();
-      vi.mocked(logoutUser).mockRejectedValue(new Error("Network error"));
+      vi.mocked(logoutApi).mockRejectedValue(new Error("Network error"));
 
       renderMainLayout();
 
@@ -157,7 +157,7 @@ describe("MainLayout", () => {
       const logoutPromise = new Promise((resolve) => {
         resolveLogout = resolve;
       });
-      vi.mocked(logoutUser).mockImplementation(() => logoutPromise);
+      vi.mocked(logoutApi).mockImplementation(() => logoutPromise);
 
       renderMainLayout();
 


### PR DESCRIPTION
- Renamed the logout function to clearAuth in AuthContext for better clarity.
- Updated MainLayout to use clearAuth instead of logout, ensuring consistent naming across the application.
- Changed the logoutUser service to logoutApi to reflect its purpose more accurately.
- Adjusted tests in MainLayout to mock and implement the new clearAuth and logoutApi functions, enhancing test reliability and clarity.